### PR TITLE
Fix packaging of reconfigure

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Package: python-reconfigure
 Architecture: all
 Homepage: http://eugeny.github.com/reconfigure
 XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, python-chardet
+Depends: ${misc:Depends}, ${python:Depends}, python-chardet, python-six
 Description: Simple config file management library

--- a/dist/reconfigure.spec.in
+++ b/dist/reconfigure.spec.in
@@ -16,7 +16,7 @@ BuildArch: noarch
 Vendor: Eugene Pankov <e@ajenti.org>
 Url: http://ajenti.org/
 
-requires: python-chardet
+requires: python-chardet, python-six
 
 %description
 Easy config file management


### PR DESCRIPTION
Fix https://github.com/ajenti/ajenti/issues/892 and https://github.com/ajenti/ajenti/issues/891

Python-six isn't installed and crash on some configs.