### PR TITLE
Remove six dependancies witch causes much trouble for old systems

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Package: python-reconfigure
 Architecture: all
 Homepage: http://eugeny.github.com/reconfigure
 XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, python-chardet, python-six
+Depends: ${misc:Depends}, ${python:Depends}, python-chardet
 Description: Simple config file management library

--- a/dist/reconfigure.spec.in
+++ b/dist/reconfigure.spec.in
@@ -16,7 +16,7 @@ BuildArch: noarch
 Vendor: Eugene Pankov <e@ajenti.org>
 Url: http://ajenti.org/
 
-requires: python-chardet, python-six
+requires: python-chardet
 
 %description
 Easy config file management

--- a/reconfigure/configs/base.py
+++ b/reconfigure/configs/base.py
@@ -37,8 +37,8 @@ class Reconfig (object):
             self.content = open(self.origin, 'r').read()
 
         self.encoding = 'utf8'
-        if (sys.version_info.major >= 3 and isinstance(self.content, bytes)) or \
-                (sys.version_info.major == 2 and isinstance(self.content, str)):
+        if (sys.version_info[0] >= 3 and isinstance(self.content, bytes)) or \
+                (sys.version_info[0] == 2 and isinstance(self.content, str)):
             try:
                 self.content = self.content.decode('utf8')
             except (UnicodeDecodeError, AttributeError):

--- a/reconfigure/configs/base.py
+++ b/reconfigure/configs/base.py
@@ -1,5 +1,4 @@
 import chardet
-import six
 import sys
 
 
@@ -38,8 +37,8 @@ class Reconfig (object):
             self.content = open(self.origin, 'r').read()
 
         self.encoding = 'utf8'
-        if (six.PY3 and isinstance(self.content, bytes)) or \
-                (six.PY2 and isinstance(self.content, str)):
+        if (sys.version_info.major >= 3 and isinstance(self.content, bytes)) or \
+                (sys.version_info.major == 2 and isinstance(self.content, str)):
             try:
                 self.content = self.content.decode('utf8')
             except (UnicodeDecodeError, AttributeError):

--- a/reconfigure/parsers/ini.py
+++ b/reconfigure/parsers/ini.py
@@ -69,7 +69,7 @@ class IniFileParser (BaseParser):
             if hasattr(cp[sectionname], '_lines'):
                 self._set_comment(cp[sectionname]._lines[0], section.comment)
 
-        data = (str if sys.version_info.major >= 3 else unicode)(cp) + u'\n'
+        data = (str if sys.version_info[0] >= 3 else unicode)(cp) + u'\n'
         if self.sectionless:
             data = data.replace('[' + self.nullsection + ']\n', '')
         return data

--- a/reconfigure/parsers/ini.py
+++ b/reconfigure/parsers/ini.py
@@ -1,4 +1,4 @@
-import six
+import sys
 
 from reconfigure.nodes import *
 from reconfigure.parsers import BaseParser
@@ -69,7 +69,7 @@ class IniFileParser (BaseParser):
             if hasattr(cp[sectionname], '_lines'):
                 self._set_comment(cp[sectionname]._lines[0], section.comment)
 
-        data = (str if six.PY3 else unicode)(cp) + u'\n'
+        data = (str if sys.version_info.major >= 3 else unicode)(cp) + u'\n'
         if self.sectionless:
             data = data.replace('[' + self.nullsection + ']\n', '')
         return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 chardet
 nose
-six

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     name='reconfigure',
     version=__version__,
     install_requires=[
-        'chardet',
-        'six',
+        'chardet'
     ],
     description='An ORM for config files',
     license='LGPLv3',


### PR DESCRIPTION
Six is used only to get the major version of python.

In old debian systems (wheezy, not so old), the six version is 1.1.0 and don't have the .PY2 or .PY3.
So, bring back the default sys.version_info.major that works in all pythons versions.

