### PR TITLE
Nginx parser should skip semicolon between quotes

### DIFF
--- a/reconfigure/parsers/nginx.py
+++ b/reconfigure/parsers/nginx.py
@@ -10,7 +10,7 @@ class NginxParser (BaseParser):
 
     tokens = [
         (r"[\w_]+\s*?[^\n]*?{", lambda s, t: ('section_start', t)),
-        (r"[\w_]+?.+?;", lambda s, t: ('option', t)),
+        (r"[\w_]+?(?:[^\"]+?(?:\".*?\")?)+?;", lambda s, t: ('option', t)),
         (r"\s", lambda s, t: 'whitespace'),
         (r"$^", lambda s, t: 'newline'),
         (r"\#.*?\n", lambda s, t: ('comment', t)),


### PR DESCRIPTION
In add_header Strict-Transport-Security "max-age=3600;" always; the previous expression matches only characters before the first semicolon.
With this version, every characters between two double-quotes are skipped.
However, it does not skip escaped double quote. I don't know if it is supported in nginx.